### PR TITLE
Update the README to add the "unmaintained" note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This project is no longer maintained! Please go to [koa-joi-router](https://github.com/koajs/joi-router)
+
 #koa-joi-router
 
 Easy, rich and fully validated [koa](http://koajs.com) routing.


### PR DESCRIPTION
This repo is the second result when typing "koa joi router" on google but weren't updated since 2015. To avoid any issues when looking for code/examples for this project i propose to include this message upfront in the README.
A **better** solution would be to just delete this fork!